### PR TITLE
Bugfix main functions

### DIFF
--- a/Menus/Experiment/ExperimentStarter.m
+++ b/Menus/Experiment/ExperimentStarter.m
@@ -243,9 +243,11 @@ else
     end
     %end of init
     try
+        handles.StartExperiment.Enable = 'off';
         Data = runExperiment(ExperimentData,hW);
     catch e
         experimentRunning = 0;
+        handles.StartExperiment.Enable = 'on';
         memdump;
         waitfor(errordlg(sprintf('Error while running the experiment! SORRY! More details in the Command Window')));
         EndofExperiment;
@@ -309,10 +311,12 @@ try
     msgbox(sprintf('Results saved (and appended) to: %s', fullfile(cd,'Results',['Results_' name '.csv'])));
 catch e
     experimentRunning = 0;
+    handles.StartExperiment.Enable = 'on';
     memdump;
     rethrow(e);
     %% TODO error handling
 end
+handles.StartExperiment.Enable = 'on';
 experimentRunning = 0;
 
 

--- a/func/Generic/memdump.m
+++ b/func/Generic/memdump.m
@@ -1,6 +1,8 @@
+function memdump
 % Take all the experiments and include them in the memdump
-save('memdump');
-gatherdata;
+    save('memdump');
+    gatherdata;
+end
 
 
 


### PR DESCRIPTION
- changed memdump to a function instead of script to prevent errors.
(function definition not allowed within a script)
- Disable the StartExperiment button in the GUI to prevent restarting an experiment when hitting Return or Spacebar at the end of an experiment.